### PR TITLE
Fix dark mode readability on mobile devices

### DIFF
--- a/template.html
+++ b/template.html
@@ -217,7 +217,7 @@
             /* Key styling */
             td:first-child {
                 font-weight: bold;
-                color: var(--suse-dark-green);
+                color: var(--th-text);
                 padding-bottom: 0;
             }
 


### PR DESCRIPTION
This change fixes a readability issue in the mobile view when dark mode is enabled. Previously, the key labels (first column) were hardcoded to a dark green color, which had poor contrast against the dark background. By switching to `var(--th-text)`, the text color now respects the theme, appearing as a lighter green in dark mode and dark green in light mode.

Verified visually using Playwright screenshots across both themes.

---
*PR created automatically by Jules for task [14488574527570378976](https://jules.google.com/task/14488574527570378976) started by @e-minguez*